### PR TITLE
Fix dark-mode toggle event handling

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -8,6 +8,8 @@
     <a href="{{ '/projects/' | relative_url }}">Projects</a>
     <a href="{{ '/blog/' | relative_url }}">Blog</a>
     <a href="{{ '/contact/' | relative_url }}">Contact</a>
-    <button id="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false">🌙</button>
+    <button id="theme-toggle" type="button" aria-label="Toggle dark mode" aria-pressed="false">
+      <span data-theme-icon aria-hidden="true">🌙</span>
+    </button>
   </nav>
 </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -47,6 +47,82 @@
     {{ content }}
   </main>
   {% include footer.html %}
-  <script src="{{ '/assets/js/theme-toggle.js' | relative_url }}" defer></script>
+  <script>
+    (function () {
+      var storageKey = 'theme';
+      var root = document.documentElement;
+      var toggle = document.querySelector('#theme-toggle, .theme-toggle, [data-theme-toggle], .toggle-dark, .mode-toggle');
+      if (!toggle) return;
+
+      var icon = toggle.querySelector('[data-theme-icon]');
+      if (!icon) {
+        icon = document.createElement('span');
+        icon.setAttribute('data-theme-icon', '');
+        icon.setAttribute('aria-hidden', 'true');
+        toggle.appendChild(icon);
+      }
+
+      function prefersDark() {
+        return !!(window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches);
+      }
+
+      function safeGet() {
+        try {
+          var stored = localStorage.getItem(storageKey);
+          if (stored === 'dark' || stored === 'light') {
+            return stored;
+          }
+        } catch (err) {
+          /* localStorage unavailable */
+        }
+        return null;
+      }
+
+      function safeSet(value) {
+        try {
+          localStorage.setItem(storageKey, value);
+        } catch (err) {
+          /* localStorage unavailable */
+        }
+      }
+
+      function currentTheme() {
+        var attr = root.getAttribute('data-theme');
+        if (attr === 'dark' || attr === 'light') {
+          return attr;
+        }
+        var stored = safeGet();
+        if (stored) {
+          return stored;
+        }
+        return prefersDark() ? 'dark' : 'light';
+      }
+
+      function updateToggle(theme) {
+        var isDark = theme === 'dark';
+        var next = isDark ? 'light' : 'dark';
+        icon.textContent = isDark ? '🌞' : '🌙';
+        toggle.setAttribute('aria-pressed', String(isDark));
+        toggle.setAttribute('aria-label', 'Switch to ' + next + ' mode');
+        toggle.setAttribute('title', 'Switch to ' + next + ' mode');
+      }
+
+      function applyTheme(theme, persist) {
+        var mode = theme === 'dark' ? 'dark' : 'light';
+        root.setAttribute('data-theme', mode);
+        updateToggle(mode);
+        if (persist) {
+          safeSet(mode);
+        }
+      }
+
+      applyTheme(currentTheme(), false);
+
+      toggle.addEventListener('click', function () {
+        var next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+        applyTheme(next, true);
+      });
+    })();
+  </script>
 </body>
 </html>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -14,22 +14,11 @@
   --accent: #2563eb;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --surface: #0f172a;
-    --surface-alt: #16213f;
-    --text: #f8fafc;
-    --muted: #cbd5f5;
-    --border: rgba(148, 163, 184, 0.25);
-    --accent: #60a5fa;
-  }
-}
-
-[data-theme="light"] {
+:root[data-theme="light"] {
   color-scheme: light;
 }
 
-[data-theme="dark"] {
+:root[data-theme="dark"] {
   color-scheme: dark;
   --surface: #0f172a;
   --surface-alt: #16213f;
@@ -37,6 +26,18 @@
   --muted: #cbd5f5;
   --border: rgba(148, 163, 184, 0.25);
   --accent: #60a5fa;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme]) {
+    color-scheme: dark;
+    --surface: #0f172a;
+    --surface-alt: #16213f;
+    --text: #f8fafc;
+    --muted: #cbd5f5;
+    --border: rgba(148, 163, 184, 0.25);
+    --accent: #60a5fa;
+  }
 }
 
 * {


### PR DESCRIPTION
## Summary
- add an inline theme toggle script that persists the selected mode, updates aria attributes, and swaps the icon
- ensure the header toggle includes a data-theme-icon span for script-driven icon updates
- key dark-mode variables off :root[data-theme="dark"] so the layout respects the chosen theme

## Testing
- bundle exec jekyll build *(fails: jekyll executable not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1a284ce94832bbeefbe1a6920390a